### PR TITLE
Add the ability to use Mozenda's client-id and secret when establishing an oauth connection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.dexi</groupId>
     <artifactId>spring-app-google-oauth</artifactId>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/src/main/java/io/dexi/google/GoogleOAuthProperties.java
+++ b/src/main/java/io/dexi/google/GoogleOAuthProperties.java
@@ -28,6 +28,9 @@ public class GoogleOAuthProperties {
 
     @NotBlank
     private String appKey;
+
+    private String mozendaClientId;
+    private String mozendaSecret;
     
     void validate() {
         if (StringUtils.isBlank(appName)) {
@@ -48,6 +51,10 @@ public class GoogleOAuthProperties {
 
         if (StringUtils.isBlank(appKey)) {
             throw new IllegalArgumentException("Missing required configuration property: google.app-key");
+        }
+
+        if (StringUtils.isNotEmpty(mozendaClientId) && StringUtils.isEmpty(mozendaSecret)) {
+            throw new IllegalArgumentException("Missing required configuration property: google.mozenda-secret");
         }
     }
 
@@ -75,12 +82,28 @@ public class GoogleOAuthProperties {
         this.clientId = clientId;
     }
 
+    public String getMozendaClientId() {
+        return mozendaClientId;
+    }
+
+    public void setMozendaClientId(String clientId) {
+        this.mozendaClientId = clientId;
+    }
+
     public String getSecret() {
         return secret;
     }
 
     public void setSecret(String secret) {
         this.secret = secret;
+    }
+
+    public String getMozendaSecret() {
+        return mozendaSecret;
+    }
+
+    public void setMozendaSecret(String secret) {
+        this.mozendaSecret = secret;
     }
 
     public String getAppKey() {

--- a/src/main/java/io/dexi/google/GoogleService.java
+++ b/src/main/java/io/dexi/google/GoogleService.java
@@ -75,38 +75,50 @@ public class GoogleService {
         ).execute();
     }
 
-    public Person getUser(OAuth2Tokens tokens) throws IOException {
-        Plus plus = createClient(tokens);
+    public Person getUser(OAuth2Tokens tokens, boolean isMozenda) throws IOException {
+        Plus plus = createClient(tokens, isMozenda);
 
         return plus.people().get("me").execute();
 
     }
 
-    private Plus createClient(OAuth2Tokens tokens) {
+    private Plus createClient(OAuth2Tokens tokens, boolean isMozenda) {
 
-        final Credential credentials = createCredentials(tokens);
+        final Credential credentials = createCredentials(tokens, isMozenda);
 
         return new Plus.Builder(transport, jacksonFactory, credentials)
                 .setApplicationName(properties.getAppName())
                 .build();
     }
 
-    private GoogleAuthorizationCodeFlow.Builder createAuthFlowBuilder() throws IOException {
-        return new GoogleAuthorizationCodeFlow.Builder(
-                transport,
-                jacksonFactory,
-                properties.getClientId(),
-                properties.getSecret(),
-                properties.getScopes()
-        ).setDataStoreFactory(dataStoreFactory);
+    private GoogleAuthorizationCodeFlow.Builder createAuthFlowBuilder(boolean isMozenda) throws IOException {
+
+        if (isMozenda) {
+            return new GoogleAuthorizationCodeFlow.Builder(
+                    transport,
+                    jacksonFactory,
+                    properties.getMozendaClientId(),
+                    properties.getMozendaSecret(),
+                    properties.getScopes()
+            ).setDataStoreFactory(dataStoreFactory);
+        }
+        else {
+            return new GoogleAuthorizationCodeFlow.Builder(
+                    transport,
+                    jacksonFactory,
+                    properties.getClientId(),
+                    properties.getSecret(),
+                    properties.getScopes()
+            ).setDataStoreFactory(dataStoreFactory);
+        }
     }
 
-    private GoogleAuthorizationCodeFlow createAuthFlow() throws IOException {
-        return createAuthFlowBuilder().build();
+    private GoogleAuthorizationCodeFlow createAuthFlow(boolean isMozenda) throws IOException {
+        return createAuthFlowBuilder(isMozenda).build();
     }
 
-    private GoogleAuthorizationCodeFlow createAuthFlow(OAuth2Tokens config) throws IOException {
-        return createAuthFlowBuilder()
+    private GoogleAuthorizationCodeFlow createAuthFlow(OAuth2Tokens config, boolean isMozenda) throws IOException {
+        return createAuthFlowBuilder(isMozenda)
                 .addRefreshListener(new CredentialRefreshListener() {
                     @Override
                     public void onTokenResponse(Credential credential, TokenResponse tokenResponse) throws IOException {
@@ -132,11 +144,11 @@ public class GoogleService {
         return tokenResponse;
     }
 
-    public Credential createCredentials(OAuth2Tokens config) {
+    public Credential createCredentials(OAuth2Tokens config, boolean isMozenda) {
 
         final GoogleAuthorizationCodeFlow authFlow;
         try {
-            authFlow = createAuthFlow(config);
+            authFlow = createAuthFlow(config, isMozenda);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to create Google OAuth flow", e);
         }

--- a/src/main/java/io/dexi/google/handlers/GoogleOAuthHandler.java
+++ b/src/main/java/io/dexi/google/handlers/GoogleOAuthHandler.java
@@ -60,7 +60,7 @@ public class GoogleOAuthHandler implements OAuth2Handler {
             out.setExpiresInSeconds(response.getExpiresInSeconds());
             out.setScope(response.getScope());
 
-            final Person user = googleService.getUser(out);
+            final Person user = googleService.getUser(out, false);
 
             for(Person.Emails email : user.getEmails()) {
                 if ("account".equalsIgnoreCase(email.getType())) {


### PR DESCRIPTION
This will be needed to use the auth tokens that Mozenda already has for customers that already do Google Drive publishing inside of Mozenda. This allows the publishing triggers to be created automatically in the integration service